### PR TITLE
Update spark and java sdk versions to resolve dependency conflicts

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 import ReleaseTransformations._
-lazy val sparkVersion = "3.2.0"
+lazy val sparkVersion = "3.4.1"
 
 ThisBuild / sonatypeCredentialHost := "s01.oss.sonatype.org"
 ThisBuild / sonatypeRepository := "https://s01.oss.sonatype.org/service/local"
@@ -13,20 +13,6 @@ lazy val root = (project in file("."))
     organization         := "io.pinecone",
     licenses := Seq(("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0"))),
     description := "A spark connector for the Pinecone Vector Database",
-    developers := List(
-      Developer(
-        "adamgs",
-        "Adam Gutglick",
-        "adam@pinecone.io",
-        url("https://github.com/pinecone-io")
-      ),
-      Developer(
-        "rajat08",
-        "Rajat Tripathi",
-        "rajat@pinecone.io",
-        url("https://github.com/pinecone-io")
-      )
-    ),
     versionScheme := Some("semver-spec"),
     scalaVersion  := "2.12.15",
     scmInfo := Some(
@@ -40,7 +26,7 @@ lazy val root = (project in file("."))
     crossScalaVersions := Seq("2.12.15", "2.13.8"),
     javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
     libraryDependencies ++= Seq(
-      "io.pinecone"       % "pinecone-client" % "0.2.2",
+      "io.pinecone"       % "pinecone-client" % "0.6.0",
       "org.scalatest"    %% "scalatest"       % "3.2.11"     % "it,test",
       "org.apache.spark" %% "spark-core"      % sparkVersion % "provided,test",
       "org.apache.spark" %% "spark-sql"       % sparkVersion % "provided,test",

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,6 @@
 import ReleaseTransformations._
-lazy val sparkVersion = "3.4.1"
+
+lazy val sparkVersion = "3.5.0"
 
 ThisBuild / sonatypeCredentialHost := "s01.oss.sonatype.org"
 ThisBuild / sonatypeRepository := "https://s01.oss.sonatype.org/service/local"
@@ -7,14 +8,14 @@ ThisBuild / sonatypeRepository := "https://s01.oss.sonatype.org/service/local"
 lazy val root = (project in file("."))
   .configs(IntegrationTest)
   .settings(
-    name                 := "spark-pinecone",
-    organizationName     := "Pinecone Systems",
+    name := "spark-pinecone",
+    organizationName := "Pinecone Systems",
     organizationHomepage := Some(url("http://pinecone.io/")),
-    organization         := "io.pinecone",
+    organization := "io.pinecone",
     licenses := Seq(("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0"))),
     description := "A spark connector for the Pinecone Vector Database",
     versionScheme := Some("semver-spec"),
-    scalaVersion  := "2.12.15",
+    scalaVersion := "2.12.15",
     scmInfo := Some(
       ScmInfo(
         url("https://github.com/pinecone-io/spark-pinecone"),
@@ -26,13 +27,13 @@ lazy val root = (project in file("."))
     crossScalaVersions := Seq("2.12.15", "2.13.8"),
     javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
     libraryDependencies ++= Seq(
-      "io.pinecone"       % "pinecone-client" % "0.6.0",
-      "org.scalatest"    %% "scalatest"       % "3.2.11"     % "it,test",
-      "org.apache.spark" %% "spark-core"      % sparkVersion % "provided,test",
-      "org.apache.spark" %% "spark-sql"       % sparkVersion % "provided,test",
-      "org.apache.spark" %% "spark-catalyst"  % sparkVersion % "provided,test"
+      "io.pinecone" % "pinecone-client" % "0.6.0",
+      "org.scalatest" %% "scalatest" % "3.2.11" % "it,test",
+      "org.apache.spark" %% "spark-core" % sparkVersion % "provided,test",
+      "org.apache.spark" %% "spark-sql" % sparkVersion % "provided,test",
+      "org.apache.spark" %% "spark-catalyst" % sparkVersion % "provided,test"
     ),
-    Test / fork       := true,
+    Test / fork := true,
     assembly / assemblyShadeRules := Seq(
       ShadeRule
         .rename("com.google.protobuf.**" -> "shaded.protobuf.@1")
@@ -45,7 +46,7 @@ lazy val root = (project in file("."))
       case PathList("META-INF", xs@_*) => MergeStrategy.concat
       case x => MergeStrategy.first
     },
-//    Build assembly jar, this builds an uberJar with all dependencies
+    // Build assembly jar, this builds an uberJar with all dependencies
     assembly / assemblyJarName := s"${name.value}-${version.value}.jar",
     assembly / artifact := {
       val art = (assembly / artifact).value
@@ -54,10 +55,10 @@ lazy val root = (project in file("."))
     addArtifact(assembly / artifact, assembly),
     publishLocal / skip := true,
     ThisBuild / publishMavenStyle := true,
-//  Expects credentials stored in ~/.sbt/sonatype_credentials. This is a standard practice
+    // Expects credentials stored in ~/.sbt/sonatype_credentials. This is a standard practice
     credentials += Credentials(Path.userHome / ".sbt" / "sonatype_credentials"),
     releaseCrossBuild := true, // true if you cross-build the project for multiple Scala versions
-    publishTo         := sonatypePublishToBundle.value,
+    publishTo := sonatypePublishToBundle.value,
     releaseProcess := Seq[ReleaseStep](
       checkSnapshotDependencies,
       inquireVersions,

--- a/src/it/scala/io/pinecone/spark/pinecone/BasicIntegrationSpec.scala
+++ b/src/it/scala/io/pinecone/spark/pinecone/BasicIntegrationSpec.scala
@@ -19,16 +19,16 @@ class BasicIntegrationSpec extends AnyFlatSpec with should.Matchers {
       .repartition(2)
 
     val pineconeOptions = Map(
-      PineconeOptions.PINECONE_API_KEY_CONF      -> System.getenv("PINECONE_API_KEY"),
-      PineconeOptions.PINECONE_ENVIRONMENT_CONF  -> System.getenv("PINECONE_ENVIRONMENT"),
+      PineconeOptions.PINECONE_API_KEY_CONF -> System.getenv("PINECONE_API_KEY"),
+      PineconeOptions.PINECONE_ENVIRONMENT_CONF -> System.getenv("PINECONE_ENVIRONMENT"),
       PineconeOptions.PINECONE_PROJECT_NAME_CONF -> System.getenv("PINECONE_PROJECT"),
-      PineconeOptions.PINECONE_INDEX_NAME_CONF   -> System.getenv("PINECONE_INDEX")
+      PineconeOptions.PINECONE_INDEX_NAME_CONF -> System.getenv("PINECONE_INDEX")
     )
 
     df.count() should be(7)
 
-//    If env variable is set run tests else skip
-    if(System.getenv("TEST_RUNNING_INDEX") != null) {
+    // If env variable is set run tests else skip
+    if (System.getenv("TEST_RUNNING_INDEX") != null) {
       df.write
         .format("io.pinecone.spark.pinecone")
         .options(pineconeOptions)
@@ -36,5 +36,4 @@ class BasicIntegrationSpec extends AnyFlatSpec with should.Matchers {
         .save()
     }
   }
-
 }

--- a/src/main/scala/io/pinecone/spark/pinecone/PineconeDataWriter.scala
+++ b/src/main/scala/io/pinecone/spark/pinecone/PineconeDataWriter.scala
@@ -1,7 +1,7 @@
 package io.pinecone.spark.pinecone
 
 import io.pinecone.proto.{UpsertRequest, Vector => PineconeVector}
-import io.pinecone.{PineconeClient, PineconeClientConfig, PineconeConnection, PineconeConnectionConfig, PineconeException}
+import io.pinecone.{PineconeClient, PineconeClientConfig, PineconeConnection, PineconeConnectionConfig}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.connector.write.{DataWriter, WriterCommitMessage}
 import org.slf4j.LoggerFactory

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.1.1"
+ThisBuild / version := "0.1.2"


### PR DESCRIPTION
## Problem

The Spark connector experienced dependency conflicts for netty on the databricks platform, as well as some warnings regarding netty when it ran in an SBT or Maven project locally. Also the mvn dependencies for spark-sql and spark-core were outdated and would not install on the databricks platform.

## Solution

Spark connector relies on the underlying pinecone java sdk. So I updated the java sdk version to 0.6.0 (latest at this time) which uses gRPC version 1.58.0, which internally uses netty version 4.1.93.Final. Also updated the spark version to `3.5.0` which is the latest at this time, working with scala 2.12. I tried testing Spark version 3.4.1 but it was still facing dependency conflicts on databricks platform. This update now resolves all netty dependencies (direct and transitive) to version 4.1.93.Final, hence resolving the underlying issue.

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Ran `sbt test` and integration test locally on a sbt project as well as on the databricks platform by first publishing the updated fat jar locally and consumed it in both projects.
