### PR TITLE
Remove auto version update

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -88,9 +88,6 @@ lazy val root = (project in file("."))
       commitReleaseVersion,
       tagRelease,
       releaseStepCommandAndRemaining("+publishSigned"),
-      releaseStepCommand("sonatypeBundleRelease"),
-      setNextVersion,
-      commitNextVersion,
-      pushChanges
+      releaseStepCommand("sonatypeBundleRelease")
     )
   )

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.1.3"
+ThisBuild / version := "0.1.2"


### PR DESCRIPTION
## Problem

The release process has auto version update code which updates and sets the version of next release, followed by committing and pushing the changes. Next version number cannot be decided at the time of current release.

## Solution

Reverted automatic setting of next version.

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

NA
