### PR TITLE
Publish uber jar to maven central as well

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -78,6 +78,7 @@ lazy val root = (project in file("."))
     // Expects credentials stored in ~/.sbt/sonatype_credentials. This is a standard practice
     credentials += Credentials(Path.userHome / ".sbt" / "sonatype_credentials"),
     releaseCrossBuild := true, // true if you cross-build the project for multiple Scala versions
+    assembly / publishTo := sonatypePublishToBundle.value,
     publishTo := sonatypePublishToBundle.value,
     releaseProcess := Seq[ReleaseStep](
       checkSnapshotDependencies,

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.1.3"
+ThisBuild / version := "0.1.4"


### PR DESCRIPTION
## Problem

Databricks platform needs an uber jar to run spark connector. Currently, the users have to download it from s3 and upload it to databricks. 

## Solution

Publish the uber jar to maven central.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [X] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

NA
