### PR TITLE
Add support for adding sparse values

### DIFF
--- a/src/it/resources/sample.jsonl
+++ b/src/it/resources/sample.jsonl
@@ -1,7 +1,98 @@
-[{"id":  "v1", "namespace": "default", "values":  [1, 2,3],"metadata": ""},
-  {"id":  "v2", "namespace": "default", "values":  [3, 2, 1],"metadata": ""},
-  {"namespace": "default", "values":  [1, 4, 9], "id":  "v3", "metadata": ""},
-  {"id":  "v4", "namespace": "default", "values":  [1, 1, 2], "metadata":  "{\"key\":  \"value\"}"},
-  {"id":  "v5", "namespace": "default", "values":  [3, 5, 8],"metadata":  "{\"key\":  \"value\"}"},
-  {"id":  "v6", "namespace": "default", "values":  [13, 21, 34],"metadata": ""},
-  {"id":  "v7", "namespace": "default", "values":  [5, 5, 5], "metadata":  "{\"hello\":  [\"world\", \"you\"], \"numbers\": \"or not\", \"actual_number\":  5.2, \"round\":  3}"}]
+[
+  {
+    "id": "v1",
+    "namespace": "default",
+    "values": [
+      1,
+      2,
+      3
+    ],
+    "metadata": "",
+    "sparse_id": [
+      0,
+      2
+    ],
+    "sparse_values": [
+      5.5,
+      5
+    ]
+  },
+  {
+    "id": "v2",
+    "namespace": "default",
+    "values": [
+      3,
+      2,
+      1
+    ],
+    "metadata": "",
+    "sparse_id": [],
+    "sparse_values": []
+  },
+  {
+    "namespace": "default",
+    "values": [
+      1,
+      4,
+      9
+    ],
+    "id": "v3",
+    "metadata": "",
+    "sparse_id": [],
+    "sparse_values": []
+  },
+  {
+    "id": "v4",
+    "namespace": "default",
+    "values": [
+      1,
+      1,
+      2
+    ],
+    "metadata": "{\"key\":  \"value\"}",
+    "sparse_id": [],
+    "sparse_values": []
+  },
+  {
+    "id": "v5",
+    "namespace": "default",
+    "values": [
+      3,
+      5,
+      8
+    ],
+    "metadata": "{\"key\":  \"value\"}",
+    "sparse_id": [],
+    "sparse_values": []
+  },
+  {
+    "id": "v6",
+    "namespace": "default",
+    "values": [
+      13,
+      21,
+      34
+    ],
+    "metadata": "",
+    "sparse_id": [],
+    "sparse_values": []
+  },
+  {
+    "id": "v7",
+    "namespace": "default",
+    "values": [
+      5,
+      5,
+      5
+    ],
+    "metadata": "{\"hello\":  [\"world\", \"you\"], \"numbers\": \"or not\", \"actual_number\":  5.2, \"round\":  3}",
+    "sparse_id": [
+      0,
+      2
+    ],
+    "sparse_values": [
+      5.5,
+      5
+    ]
+  }
+]

--- a/src/main/scala/io/pinecone/spark/pinecone/package.scala
+++ b/src/main/scala/io/pinecone/spark/pinecone/package.scala
@@ -1,9 +1,9 @@
 package io.pinecone.spark
 
-import com.fasterxml.jackson.databind.{DeserializationFeature, ObjectMapper}
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.google.protobuf.{ListValue, Struct, Value}
 import org.apache.spark.sql.connector.write.WriterCommitMessage
-import org.apache.spark.sql.types.{ArrayType, FloatType, StringType, StructType}
+import org.apache.spark.sql.types.{ArrayType, FloatType, IntegerType, StringType, StructType}
 
 import scala.collection.JavaConverters._
 
@@ -15,26 +15,29 @@ package object pinecone {
       .add("namespace", StringType)
       .add("values", ArrayType(FloatType))
       .add("metadata", StringType)
+      .add("sparse_id", ArrayType(IntegerType, containsNull = true), nullable = true)
+      .add("sparse_values", ArrayType(FloatType, containsNull = true), nullable = true)
 
-  private[pinecone] val MAX_ID_LENGTH     = 512
+  private[pinecone] val MAX_ID_LENGTH = 512
   private[pinecone] val MAX_METADATA_SIZE = 5 * math.pow(10, 3) // 5KB
-  private[pinecone] val MAX_REQUEST_SIZE  = 2 * math.pow(10, 6) // 2MB
+  private[pinecone] val MAX_REQUEST_SIZE = 2 * math.pow(10, 6) // 2MB
 
   /** Parses the metadata of a vector from a JSON string representation to a ProtoBuf struct
-    * @param vectorId
-    *   the ID of the vector, used for error reporting purposes
-    * @param metadataStr
-    *   \- the JSON string representing the vector's metadata
-    * @return
-    */
+   *
+   * @param vectorId
+   * the ID of the vector, used for error reporting purposes
+   * @param metadataStr
+   * \- the JSON string representing the vector's metadata
+   * @return
+   */
   private[pinecone] def parseAndValidateMetadata(vectorId: String, metadataStr: String): Struct = {
     val structBuilder = Struct.newBuilder()
-    val mapper        = new ObjectMapper()
+    val mapper = new ObjectMapper()
 
     val jsonTree = mapper.readTree(metadataStr)
 
     for (jsonField <- jsonTree.fields().asScala) {
-      val key   = jsonField.getKey
+      val key = jsonField.getKey
       val value = jsonField.getValue
 
       if (value.isTextual) {
@@ -44,7 +47,7 @@ package object pinecone {
       } else if (value.isBoolean) {
         structBuilder.putFields(key, Value.newBuilder().setBoolValue(value.booleanValue()).build())
       } else if (value.isArray && value.elements().asScala.toArray.forall(_.isTextual)) {
-        val arrayElements    = value.elements().asScala.toArray
+        val arrayElements = value.elements().asScala.toArray
         val listValueBuilder = ListValue.newBuilder()
         listValueBuilder.addAllValues(
           arrayElements
@@ -75,11 +78,12 @@ package object pinecone {
 
   trait PineconeException extends Exception {
     def getMessage: String
+
     def vectorId: String
   }
 
   case class InvalidVectorMetadataException(vectorId: String, jsonKey: String)
-      extends PineconeException {
+    extends PineconeException {
     override def getMessage: String =
       s"Vector with ID '$vectorId' has invalid metadata field '$jsonKey'. Please refer to the Pinecone.io docs for a longer explanation."
   }
@@ -94,8 +98,7 @@ package object pinecone {
       s"Vector with ID starting with ${vectorId.substring(0, 8)}. Must be 512 characters or less. actual: ${vectorId.length}"
   }
 
-  case class NullValueException(vectorId:String) extends PineconeException {
+  case class NullValueException(vectorId: String) extends PineconeException {
     override def getMessage: String = "Null id or value column found in row. Please ensure id and values are not null."
-
   }
 }


### PR DESCRIPTION
## Problem

Currently the spark connector lacks support to add sparse vectors 

## Solution

Add support for adding sparse vectors to upsert calls

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Ran integration test locally to upsert dense and sparse vectors.
