### PR TITLE
Update readme and version for next release

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,8 @@ df = spark.createDataFrame(data=embeddings, schema=schema)
 
 ### Scala
 ```scala
-import io.pinecone.spark.pinecone.PineconeOptions
+import io.pinecone.spark.pinecone.{COMMON_SCHEMA, PineconeOptions}
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.types.{ArrayType, FloatType, StringType, StructType}
 import org.apache.spark.sql.{SaveMode, SparkSession}
 
 object MainApp extends App {

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # spark-pinecone
-
 The official [pinecone.io](https://pinecone.io) spark connector.
 
 ## Features
@@ -10,31 +9,28 @@ If you need to use the connector with a streaming pipeline, it is recommended to
 
 ## Support
 This client currently only supports Spark 3.5.0, Scala 2.12.X or 2.13.X and Java 8+.
+- For Scala 2.12, use `spark-pinecone_2.12.jar`.
+- For Scala 2.13, use `spark-pinecone_2.13.jar`.
+
+Make sure to add the correct JAR file to your project's dependencies according to your Scala version.
 
 ### Databricks and friends
 Due to various libraries provided by Databricks (and other runtimes), please use the assembly jar from s3 for now.
 S3 path for assembly jar: s3://pinecone-jars/spark-pinecone-uberjar.jar
 
 ## Usage
-
 add the following snippet to your `built.sbt` file:
 ```scala
-libraryDependencies += "io.pinecone" %% "spark-pinecone" % "0.1.0"
+libraryDependencies += "io.pinecone" %% "spark-pinecone" % "<spark_pinecone_sdk_version>" // example of the spark_pinecone_sdk_version => 0.1.4 and you can get the latest version from maven central or release notes.
 ```
 
-
 ## Example
-
 To connect to Pinecone with Spark you'll have to retrieve the following information from [your Pinecone console](https://app.pinecone.io)
-
-1. API Key: navigate to your project and click the "API Keys" button on the sidebar
+1. API Key: navigate to your project and click the "API Keys" button on the sidebar.
 2. `environment` & `projectName`: check the browser url to fetch the environment. `https://app.pinecone.io/organizations/[org-id]/projects/[environment]:[project_name]/indexes`
 
-
 ### PySpark
-
 ```python
-
 from pyspark import SparkConf
 from pyspark.sql import SparkSession
 from pyspark.sql.types import StructType, StructField, ArrayType, FloatType, StringType
@@ -63,36 +59,39 @@ df = spark.createDataFrame(data=embeddings, schema=schema)
     .mode("append")
     .save()
 )
-
-
 ```
 
 ### Scala
-
 ```scala
+import io.pinecone.spark.pinecone.PineconeOptions
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.types._
+import org.apache.spark.sql.types.{ArrayType, FloatType, StringType, StructType}
 import org.apache.spark.sql.{SaveMode, SparkSession}
 
 object MainApp extends App {
+  val apiKey = "PINECONE_API_KEY"
+  val environment = "PINECONE_ENVIRONMENT"
+  val projectName = "PINECONE_PROJECT_NAME"
+  val indexName = "PINECONE_INDEX_NAME"
+
   val conf = new SparkConf()
     .setMaster("local[*]")
   val spark = SparkSession.builder().config(conf).getOrCreate()
 
   val df = spark.read
-    .schema(new StructType()
-      .add("id", StringType,false)
-      .add("namespace", StringType)
-      .add("values", ArrayType(FloatType),false)
-      .add("metadata", StringType))
-    .json("src/test/resources/sample.jsonl")
+    .option("multiLine", value = true)
+    .option("mode", "PERMISSIVE")
+    .schema(COMMON_SCHEMA)
+    .json("src/test/resources/sample.jsonl") // path to sample.jsonl
 
   val pineconeOptions = Map(
-    "pinecone.apiKey" -> "YOUR_API_KEY_HERE",
-    "pinecone.environment" -> "ENV_NAME",
-    "pinecone.projectName" -> "PROJECT_NAME_HERE",
-    "pinecone.indexName" -> "INDEX_NAME"
+    PineconeOptions.PINECONE_API_KEY_CONF -> apiKey,
+    PineconeOptions.PINECONE_ENVIRONMENT_CONF -> environment,
+    PineconeOptions.PINECONE_PROJECT_NAME_CONF -> projectName,
+    PineconeOptions.PINECONE_INDEX_NAME_CONF -> indexName
   )
+
+  df.show(df.count().toInt)
 
   df.write
     .options(pineconeOptions)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.1.4"
+ThisBuild / version := "0.2.0"


### PR DESCRIPTION
## Problem

It is confusing to users on why there are 2 spark pinecone jars, spark-pinecone_2.13 and spark-pinecone_2.12. Also update the version for next release.

## Solution

Explained how spark-pinecone_2.13 and spark-pinecone_2.12 are for Scala 2.13 and 2.12 respectively. Also updated the version to 0.2.0 as we have added support for sparse vectors now.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [X] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Ran sbt test and integration test with the locally published jar reflecting v0.2.0.