### PR TITLE
Update README with s3 path for latest jar and clean up sample.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ Make sure to add the correct JAR file to your project's dependencies according t
 
 ### Databricks and friends
 Due to various libraries provided by Databricks (and other runtimes), please use the assembly jar from s3 for now.
-S3 path for assembly jar: s3://pinecone-jars/spark-pinecone-uberjar.jar
+S3 path for assembly jar: 
+1. v0.2.1 (latest): s3://pinecone-jars/0.2.1/spark-pinecone-uberjar.jar
+2. v0.1.4: s3://pinecone-jars/spark-pinecone-uberjar.jar
 
 ## Usage
 add the following snippet to your `built.sbt` file:

--- a/src/it/resources/sample.jsonl
+++ b/src/it/resources/sample.jsonl
@@ -7,7 +7,15 @@
       2,
       3
     ],
-    "metadata": "{\"hello\":  [\"world\", \"you\"], \"numbers\": \"or not\", \"actual_number\":  5.2, \"round\":  3}",
+    "metadata": {
+      "hello": [
+        "world",
+        "you"
+      ],
+      "numbers": "or not",
+      "actual_number": 5.2,
+      "round": 3
+    },
     "sparse_values": {
       "indices": [
         0,
@@ -45,7 +53,9 @@
       1,
       2
     ],
-    "metadata": "{\"key\":  \"value\"}"
+    "metadata": {
+      "key": "value"
+    }
   },
   {
     "id": "v5",
@@ -55,7 +65,9 @@
       5,
       8
     ],
-    "metadata": "{\"key\":  \"value\"}",
+    "metadata": {
+      "key": "value"
+    },
     "sparse_values": {
       "indices": [
         1
@@ -83,6 +95,14 @@
       6,
       7
     ],
-    "metadata": "{\"hello\":  [\"world\", \"you\"], \"numbers\": \"or not\", \"actual_number\":  5.2, \"round\":  3}"
+    "metadata": {
+      "hello": [
+        "world",
+        "you"
+      ],
+      "numbers": "or not",
+      "actual_number": 5.2,
+      "round": 3
+    }
   }
 ]


### PR DESCRIPTION
## Problem

We release v0.2.1 for spark pinecone connector, so the read me file should show the correct s3 path. Along with that, the sample.json file needs clean up.

## Solution

Updated README with s3 path for v0.2.1 assembly jar and cleaned up sample.json

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [X] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Ran integration tests locally and on databricks platform.
