### PR TITLE
Update pinecone-java-sdk version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -47,7 +47,7 @@ lazy val root = (project in file("."))
     crossScalaVersions := Seq("2.12.15", "2.13.8"),
     javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
     libraryDependencies ++= Seq(
-      "io.pinecone" % "pinecone-client" % "0.6.0",
+      "io.pinecone" % "pinecone-client" % "0.7.4",
       "org.scalatest" %% "scalatest" % "3.2.11" % "it,test",
       "org.apache.spark" %% "spark-core" % sparkVersion % "provided,test",
       "org.apache.spark" %% "spark-sql" % sparkVersion % "provided,test",

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.2.1"
+ThisBuild / version := "0.2.2"


### PR DESCRIPTION
## Problem

The Spark connector uses pinecone-client java sdk v0.6.0 and while spark-connector doesn't support index creation, the java sdk does and its broken for v0.6.0. 

## Solution

Update the underlying java sdk to v0.7.4. 

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
Run integration tests and consume the SDK in databricks before.
Describe specific steps for validating this change.
