### PR TITLE
Change the sparse_values indices to LongType to work with pinecone-text.

### DIFF
--- a/src/main/scala/io/pinecone/spark/pinecone/PineconeDataWriter.scala
+++ b/src/main/scala/io/pinecone/spark/pinecone/PineconeDataWriter.scala
@@ -62,7 +62,7 @@ case class PineconeDataWriter(
       if (!record.isNullAt(4)) {
         val sparseVectorStruct = record.getStruct(4, 2)
         if (!sparseVectorStruct.isNullAt(0) && !sparseVectorStruct.isNullAt(1)) {
-          val sparseId = sparseVectorStruct.getArray(0).toIntArray().map(int2Integer).toIterable
+          val sparseId = sparseVectorStruct.getArray(0).toLongArray().map(_.toInt).map(int2Integer).toIterable
           val sparseValues = sparseVectorStruct.getArray(1).toFloatArray().map(float2Float).toIterable
 
           val sparseDataBuilder = SparseValues.newBuilder()

--- a/src/main/scala/io/pinecone/spark/pinecone/package.scala
+++ b/src/main/scala/io/pinecone/spark/pinecone/package.scala
@@ -3,7 +3,7 @@ package io.pinecone.spark
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.google.protobuf.{ListValue, Struct, Value}
 import org.apache.spark.sql.connector.write.WriterCommitMessage
-import org.apache.spark.sql.types.{ArrayType, FloatType, IntegerType, StringType, StructField, StructType}
+import org.apache.spark.sql.types.{ArrayType, FloatType, LongType, StringType, StructField, StructType}
 
 import scala.collection.JavaConverters._
 
@@ -16,7 +16,7 @@ package object pinecone {
       .add("metadata", StringType, nullable = true)
       .add("sparse_values", StructType(
         Array(
-          StructField("indices", ArrayType(IntegerType, containsNull = false), nullable = false),
+          StructField("indices", ArrayType(LongType, containsNull = false), nullable = false),
           StructField("values", ArrayType(FloatType, containsNull = false), nullable = false)
         )
       ), nullable = true)


### PR DESCRIPTION
## Problem

See #26 for a long discussion of the problem here.  Basically, this makes the spark-pinecone connector compatible with the unsigned integer index values that come from pinecone-text.  Currently, they overflow the spark `IntegerType`.

cc @rohanshah18 

## Solution

This makes the `indices` field of the `sparse_values` struct spark `LongType` instead of `IntegerType`.  When mapped to integers in the scala code, overflow values wrap around and become negative, but protobuf and pinecone interpret them correctly on the other side as unsigned ints.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test

I built the assembly jar locally, uploaded it to s3, and verified it in databricks by upserting ~130k sparse vectors that were generated with pinecone-text.  I also compared a single sparse vector in the pinecone UI to make sure that the index values were exactly the same as the ones in the spark dataframe.
