### PR TITLE
Remove extra variables from scala-spark example and remove runTest step from release process

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,6 @@ import org.apache.spark.sql.{SaveMode, SparkSession}
 
 object MainApp extends App {
   val apiKey = "PINECONE_API_KEY"
-  val environment = "PINECONE_ENVIRONMENT"
-  val projectName = "PINECONE_PROJECT_NAME"
   val indexName = "PINECONE_INDEX_NAME"
 
   val conf = new SparkConf()

--- a/build.sbt
+++ b/build.sbt
@@ -85,7 +85,6 @@ lazy val root = (project in file("."))
       checkSnapshotDependencies,
       inquireVersions,
       runClean,
-      runTest,
       setReleaseVersion,
       commitReleaseVersion,
       tagRelease,


### PR DESCRIPTION
## Problem

Scala-spark example has extra variables instantiated and the release process has runTests step.

## Solution

Remove environment and projectName variables from scala-spark example of README and remove runTests step from release process

## Type of Change
- [X] Non-code change (docs, etc)

## Test Plan
NA