### PR TITLE
Update max metadata size to 40 KB

### DIFF
--- a/src/main/scala/io/pinecone/spark/pinecone/package.scala
+++ b/src/main/scala/io/pinecone/spark/pinecone/package.scala
@@ -22,7 +22,7 @@ package object pinecone {
       ), nullable = true)
 
   private[pinecone] val MAX_ID_LENGTH = 512
-  private[pinecone] val MAX_METADATA_SIZE = 5 * math.pow(10, 3) // 5KB
+  private[pinecone] val MAX_METADATA_SIZE = 40 * math.pow(10, 3) // 40KB
   private[pinecone] val MAX_REQUEST_SIZE = 2 * math.pow(10, 6) // 2MB
 
   /** Parses the metadata of a vector from a JSON string representation to a ProtoBuf struct


### PR DESCRIPTION
## Problem

Max metadata size at Pinecone is 40 KB but it was set to 5 KB in spark-connector.

## Solution

Update max metadata size to 40 KB

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)

## Test Plan

Upsert records by publishing the jar locally in a sbt project
