### PR TITLE
Update java sdk to v1.2.2. and add source tag

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -47,7 +47,7 @@ lazy val root = (project in file("."))
     crossScalaVersions := Seq("2.12.15", "2.13.8"),
     javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
     libraryDependencies ++= Seq(
-      "io.pinecone" % "pinecone-client" % "1.0.0",
+      "io.pinecone" % "pinecone-client" % "1.2.2",
       "org.scalatest" %% "scalatest" % "3.2.11" % "it,test",
       "org.apache.spark" %% "spark-core" % sparkVersion % "provided,test",
       "org.apache.spark" %% "spark-sql" % sparkVersion % "provided,test",

--- a/src/it/scala/io/pinecone/spark/pinecone/BasicIntegrationSpec.scala
+++ b/src/it/scala/io/pinecone/spark/pinecone/BasicIntegrationSpec.scala
@@ -22,7 +22,8 @@ class BasicIntegrationSpec extends AnyFlatSpec with should.Matchers {
 
     val pineconeOptions = Map(
       PineconeOptions.PINECONE_API_KEY_CONF -> System.getenv("PINECONE_API_KEY"),
-      PineconeOptions.PINECONE_INDEX_NAME_CONF -> System.getenv("PINECONE_INDEX")
+      PineconeOptions.PINECONE_INDEX_NAME_CONF -> System.getenv("PINECONE_INDEX"),
+      PineconeOptions.PINECONE_SOURCE_TAG_CONF -> System.getenv("PINECONE_SOURCE_TAG")
     )
 
     df.write

--- a/src/main/scala/io/pinecone/spark/pinecone/PineconeDataWriter.scala
+++ b/src/main/scala/io/pinecone/spark/pinecone/PineconeDataWriter.scala
@@ -17,7 +17,7 @@ case class PineconeDataWriter(
                              ) extends DataWriter[InternalRow]
   with Serializable {
   private val log = LoggerFactory.getLogger(getClass)
-  private val config: PineconeConfig = new PineconeConfig(options.apiKey)
+  private val config: PineconeConfig = new PineconeConfig(options.apiKey, options.sourceTag)
   private val pinecone: PineconeClient = new PineconeClient.Builder(options.apiKey).build()
   config.setHost(pinecone.describeIndex(options.indexName).getHost)
   private val conn: PineconeConnection = new PineconeConnection(config)

--- a/src/main/scala/io/pinecone/spark/pinecone/PineconeOptions.scala
+++ b/src/main/scala/io/pinecone/spark/pinecone/PineconeOptions.scala
@@ -12,11 +12,17 @@ class PineconeOptions(config: CaseInsensitiveStringMap) extends Serializable {
 
   val apiKey: String = getKey(PINECONE_API_KEY_CONF, config)
   val indexName: String = getKey(PINECONE_INDEX_NAME_CONF, config)
+  val sourceTag: String = getSourceTag(config)
 
   private def getKey(key: String, config: CaseInsensitiveStringMap): String = {
     Option(config.get(key)).getOrElse(
       throw new RuntimeException(s"Missing required parameter $key")
     )
+  }
+
+  private def getSourceTag(config: CaseInsensitiveStringMap): String = {
+    val value = Option(config.get(PINECONE_SOURCE_TAG_CONF)).getOrElse("")
+    s"spark_$value"
   }
 }
 
@@ -24,4 +30,5 @@ object PineconeOptions {
   val PINECONE_BATCH_SIZE_CONF: String   = "pinecone.batchSize"
   val PINECONE_API_KEY_CONF: String      = "pinecone.apiKey"
   val PINECONE_INDEX_NAME_CONF: String   = "pinecone.indexName"
+  val PINECONE_SOURCE_TAG_CONF: String   = "pinecone.sourceTag"
 }


### PR DESCRIPTION
## Problem

Source tag functionality was missing.

## Solution

Update the Java SDK to version 1.2.2 to use the source tag functionality. Users can pass a source tag, and regardless of whether the string is empty or not, spark_ will be prepended to the source tag string.

## Type of Change

- [X] New feature (non-breaking change which adds functionality)

## Test Plan

Updated the integration test and checked for both scenarios where source was passed as empty and non-empty strings. The asana ticket has datadog screenshots of user agents string being populated for both scenarios.
